### PR TITLE
Normalize Categories

### DIFF
--- a/data/manual.json
+++ b/data/manual.json
@@ -403,7 +403,7 @@
       {
         "code": "", 
         "name": "Reviewers' Guide",
-        "subject": "",
+        "subject": "Reviewers' Guide",
         "links": [], 
         "subcontents": [
           {

--- a/data/subjects.json
+++ b/data/subjects.json
@@ -1,0 +1,8 @@
+{
+    "bible stories":                             "Bible Stories",
+    "bible translation comprehension questions": "Translation Questions",
+    "greek new testament":                       "Bible",
+    "translator notes":                          "Translation Notes",
+    "translator questions":                      "Translation Questions",
+    "translator words":                          "Translation Words"
+}

--- a/functions.js
+++ b/functions.js
@@ -2,6 +2,7 @@ const {
   getFileFormat,
   getZipContent,
   getCategory,
+  normalizeSubject,
   getBookSortOrder,
   removeProperty,
   flattenOnce,
@@ -22,7 +23,7 @@ function mapContents(languages) {
     contents: l.contents.map(content => ({
       name: content.title,
       code: content.identifier,
-      subject: content.subject,
+      subject: normalizeSubject(content.subject),
       description: content.description,
       checkingLevel: content.checking.checking_level,
       links: content.formats,

--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,5 @@
 const books = require('./data/books.json');
+const subjects = require('./data/subjects.json');
 const contentOrder = require('./data/content_order.json');
 
 /**
@@ -72,6 +73,14 @@ function getCategory(bookCode) {
 /**
  *
  */
+function normalizeSubject(subject) {
+    const subjectLowercase = subject.toLowerCase();
+    return subjects[subjectLowercase] || subject;
+}
+
+/**
+ *
+ */
 function getBookSortOrder(bookCode) {
   const code = bookCode.toLowerCase();
   return (books[code] && books[code]["num"]) || 0;
@@ -82,6 +91,7 @@ module.exports = {
   getZipContent,
   orderContent,
   getCategory,
+  normalizeSubject,
   getBookSortOrder,
   removeProperty,
   flattenOnce,


### PR DESCRIPTION
This change makes the following changes:  

- fixes an issue where categories from external sources were conflicting with categories from internal sources.  External source categories (called "subjects" in the code) are mapped to the matching categories for internal sources.

- Put reviewers' guides into their own category.
