### PR TITLE
Update content naming and filtering per DM

### DIFF
--- a/data/content_filters.json
+++ b/data/content_filters.json
@@ -1,3 +1,3 @@
 {
-    "en": [ "ulb", "udb", "tn", "tq", "tw", "ta" ]
+    "en": [ "ulb", "udb", "tn", "tq", "tw", "ta", "ust", "ult", "obs-tq" ]
 }

--- a/data/manual.json
+++ b/data/manual.json
@@ -3398,7 +3398,7 @@
       },
       {
         "code": "ta-wa",
-        "name": "ULB Translation Manual",
+        "name": "Wycliffe Associates Translation Manual",
         "subject": "Translation Academy",
         "checkingLevel": "3",
         "links": [


### PR DESCRIPTION
This PR contains the following changes:

- Rename ULB Translation Manual -> Wycliffe Associates Translation Manual.
- Removed UST
- Removed ULT
- Removed OBS-TQ (that was the "Unknown" section.)