### PR TITLE
Change manual URL of en_tm (prev. en_ta)

### DIFF
--- a/data/manual.json
+++ b/data/manual.json
@@ -3403,7 +3403,7 @@
         "checkingLevel": "3",
         "links": [
           {
-            "url": "https://door43.org/u/WycliffeAssociates/en_ta",
+            "url": "https://read.bibletranslationtools.org/u/WycliffeAssociates/en_tm",
             "zipContent": "",
             "quality": "",
             "format": "Read on Web"


### PR DESCRIPTION
The en_ta resource was moved to WACS and renamed to en_tm.  This changes updates the manual index to point to the new location.