### PR TITLE
Filter download links, fix bugs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,5 @@ npm start &
 sleep 10s
 
 # Get json file from server
-wget --output-document=/working/data.json localhost:8081/massaged/json
+cd /working
+wget --output-document=data.json localhost:8081/massaged/json

--- a/functions.js
+++ b/functions.js
@@ -75,8 +75,16 @@ function filterContentLinks(languages) {
     contents: l.contents.map(c => ({
       ...c,
       links: c.links && c.links.length > 0 ? c.links.filter((link) => {
+          // Special case: If this is a download link,
+          // MS wants only ulb, udb, reg to be listed
+          if (link.format === 'Download') {
+              const regDownload = c.code.startsWith("reg");
+              const ulbDownload = c.code.startsWith("ulb");
+              const udbDownload = c.code.startsWith("udb");
+              return regDownload || ulbDownload || udbDownload
+          }
           // Special case: MS wants obs-download filtered for now
-          const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
+          // const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
           // if (c.code.startsWith("obs")) {
           //     console.log("Filtering l=" + l.code)
           //     console.log("Filtering c=" + c.code)
@@ -84,7 +92,8 @@ function filterContentLinks(languages) {
           //     console.log("Filtering link.format=" + link.format)
           //     console.log("notObsDownload=" + notObsDownload)
           // }
-          return notObsDownload
+          // return notObsDownload
+          return true;
         })
         : [],
     })),

--- a/functions.js
+++ b/functions.js
@@ -165,14 +165,14 @@ function filterSubcontentLinks(languages) {
           links: s.links && s.links.length > 0 ? s.links.filter((link) => {
               // Special case: MS wants obs-download filtered for now
               const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
-              if (c.code.startsWith("obs")) {
-                  console.log("Filtering l=" + l.code)
-                  console.log("Filtering c=" + c.code)
-                  console.log("Filtering s=" + s.code)
-                  console.log("Filtering link.url=" + link.url)
-                  console.log("Filtering link.format=" + link.format)
-                  console.log("notObsDownload=" + notObsDownload)
-              }
+              // if (c.code.startsWith("obs")) {
+              //     console.log("Filtering l=" + l.code)
+              //     console.log("Filtering c=" + c.code)
+              //     console.log("Filtering s=" + s.code)
+              //     console.log("Filtering link.url=" + link.url)
+              //     console.log("Filtering link.format=" + link.format)
+              //     console.log("notObsDownload=" + notObsDownload)
+              // }
               return notObsDownload
             })
             : [],

--- a/functions.js
+++ b/functions.js
@@ -164,9 +164,9 @@ function filterSubcontentLinks(languages) {
           ...s,
           links: s.links && s.links.length > 0 ? s.links.filter((link) => {
               // Special case: MS wants only ulb, udb, reg to be listed
-              const regDownload = !(c.code.startsWith("reg") && link.format === 'Download');
-              const ulbDownload = !(c.code.startsWith("ulb") && link.format === 'Download');
-              const udbDownload = !(c.code.startsWith("udb") && link.format === 'Download');
+              const regDownload = c.code.startsWith("reg") && link.format === 'Download';
+              const ulbDownload = c.code.startsWith("ulb") && link.format === 'Download';
+              const udbDownload = c.code.startsWith("udb") && link.format === 'Download';
               // Special case: MS wants obs-download filtered for now
               // const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
               // if (c.code.startsWith("obs")) {

--- a/functions.js
+++ b/functions.js
@@ -75,24 +75,13 @@ function filterContentLinks(languages) {
     contents: l.contents.map(c => ({
       ...c,
       links: c.links && c.links.length > 0 ? c.links.filter((link) => {
-          // Special case: If this is a download link,
-          // MS wants only ulb, udb, reg to be listed
+          // Special case: Per MS, only list download links for reg, ulb, udb
           if (link.format === 'Download') {
               const regDownload = c.code.startsWith("reg");
               const ulbDownload = c.code.startsWith("ulb");
               const udbDownload = c.code.startsWith("udb");
               return regDownload || ulbDownload || udbDownload
           }
-          // Special case: MS wants obs-download filtered for now
-          // const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
-          // if (c.code.startsWith("obs")) {
-          //     console.log("Filtering l=" + l.code)
-          //     console.log("Filtering c=" + c.code)
-          //     console.log("Filtering link.url=" + link.url)
-          //     console.log("Filtering link.format=" + link.format)
-          //     console.log("notObsDownload=" + notObsDownload)
-          // }
-          // return notObsDownload
           return true;
         })
         : [],
@@ -172,25 +161,13 @@ function filterSubcontentLinks(languages) {
         ? c.subcontents.map(s => ({
           ...s,
           links: s.links && s.links.length > 0 ? s.links.filter((link) => {
-              // Special case: If this is a download link,
-              // MS wants only ulb, udb, reg to be listed
+              // Special case: Per MS, only list download links for reg, ulb, udb
               if (link.format === 'Download') {
                   const regDownload = c.code.startsWith("reg");
                   const ulbDownload = c.code.startsWith("ulb");
                   const udbDownload = c.code.startsWith("udb");
                   return regDownload || ulbDownload || udbDownload
               }
-              // Special case: MS wants obs-download filtered for now
-              // const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
-              // if (c.code.startsWith("obs")) {
-              //     console.log("Filtering l=" + l.code)
-              //     console.log("Filtering c=" + c.code)
-              //     console.log("Filtering s=" + s.code)
-              //     console.log("Filtering link.url=" + link.url)
-              //     console.log("Filtering link.format=" + link.format)
-              //     console.log("notObsDownload=" + notObsDownload)
-              // }
-              // return notObsDownload
               return true;
             })
             : [],

--- a/functions.js
+++ b/functions.js
@@ -69,6 +69,28 @@ function filterContents(languages) {
     }));
 }
 
+function filterContentLinks(languages) {
+  return languages.map(l => ({
+    ...l,
+    contents: l.contents.map(c => ({
+      ...c,
+      links: c.links && c.links.length > 0 ? c.links.filter((link) => {
+          // Special case: MS wants obs-download filtered for now
+          const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
+          // if (c.code.startsWith("obs")) {
+          //     console.log("Filtering l=" + l.code)
+          //     console.log("Filtering c=" + c.code)
+          //     console.log("Filtering link.url=" + link.url)
+          //     console.log("Filtering link.format=" + link.format)
+          //     console.log("notObsDownload=" + notObsDownload)
+          // }
+          return notObsDownload
+        })
+        : [],
+    })),
+  }));
+}
+
 function mapSubcontents(languages) {
   return languages.map(l => ({
     ...l,
@@ -125,6 +147,34 @@ function mapSubcontentLinks(languages) {
               // OBS subcontent has, oddly, chapters inside each links.
               chapters: link.chapters || [],
             }))
+            : [],
+        }))
+        : [],
+    })),
+  }));
+}
+
+function filterSubcontentLinks(languages) {
+  return languages.map(l => ({
+    ...l,
+    contents: l.contents.map(c => ({
+      ...c,
+      subcontents: c.subcontents && c.subcontents.length > 0
+        ? c.subcontents.map(s => ({
+          ...s,
+          links: s.links && s.links.length > 0 ? s.links.filter((link) => {
+              // Special case: MS wants obs-download filtered for now
+              const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
+              if (c.code.startsWith("obs")) {
+                  console.log("Filtering l=" + l.code)
+                  console.log("Filtering c=" + c.code)
+                  console.log("Filtering s=" + s.code)
+                  console.log("Filtering link.url=" + link.url)
+                  console.log("Filtering link.format=" + link.format)
+                  console.log("notObsDownload=" + notObsDownload)
+              }
+              return notObsDownload
+            })
             : [],
         }))
         : [],
@@ -290,10 +340,12 @@ module.exports = {
   mapLanguages,
   mapContents,
   mapContentLinks,
+  filterContentLinks,
   filterContents,
   mapSubcontents,
   filterSubcontents,
   mapSubcontentLinks,
+  filterSubcontentLinks,
   addEnglishNames,
   sortLanguageByNameOrEnglishName,
   sortContents,

--- a/functions.js
+++ b/functions.js
@@ -163,8 +163,12 @@ function filterSubcontentLinks(languages) {
         ? c.subcontents.map(s => ({
           ...s,
           links: s.links && s.links.length > 0 ? s.links.filter((link) => {
+              // Special case: MS wants only ulb, udb, reg to be listed
+              const regDownload = !(c.code.startsWith("reg") && link.format === 'Download');
+              const ulbDownload = !(c.code.startsWith("ulb") && link.format === 'Download');
+              const udbDownload = !(c.code.startsWith("udb") && link.format === 'Download');
               // Special case: MS wants obs-download filtered for now
-              const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
+              // const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
               // if (c.code.startsWith("obs")) {
               //     console.log("Filtering l=" + l.code)
               //     console.log("Filtering c=" + c.code)
@@ -173,7 +177,8 @@ function filterSubcontentLinks(languages) {
               //     console.log("Filtering link.format=" + link.format)
               //     console.log("notObsDownload=" + notObsDownload)
               // }
-              return notObsDownload
+              // return notObsDownload
+              return regDownload || ulbDownload || udbDownload
             })
             : [],
         }))

--- a/functions.js
+++ b/functions.js
@@ -163,10 +163,14 @@ function filterSubcontentLinks(languages) {
         ? c.subcontents.map(s => ({
           ...s,
           links: s.links && s.links.length > 0 ? s.links.filter((link) => {
-              // Special case: MS wants only ulb, udb, reg to be listed
-              const regDownload = c.code.startsWith("reg") && link.format === 'Download';
-              const ulbDownload = c.code.startsWith("ulb") && link.format === 'Download';
-              const udbDownload = c.code.startsWith("udb") && link.format === 'Download';
+              // Special case: If this is a download link,
+              // MS wants only ulb, udb, reg to be listed
+              if (link.format === 'Download') {
+                  const regDownload = c.code.startsWith("reg");
+                  const ulbDownload = c.code.startsWith("ulb");
+                  const udbDownload = c.code.startsWith("udb");
+                  return regDownload || ulbDownload || udbDownload
+              }
               // Special case: MS wants obs-download filtered for now
               // const notObsDownload = !(c.code.startsWith("obs") && link.format === 'Download');
               // if (c.code.startsWith("obs")) {
@@ -178,7 +182,7 @@ function filterSubcontentLinks(languages) {
               //     console.log("notObsDownload=" + notObsDownload)
               // }
               // return notObsDownload
-              return regDownload || ulbDownload || udbDownload
+              return true;
             })
             : [],
         }))

--- a/index.js
+++ b/index.js
@@ -9,10 +9,12 @@ const {
   mapLanguages,
   mapContents,
   mapContentLinks,
+  filterContentLinks,
   filterContents,
   mapSubcontents,
   filterSubcontents,
   mapSubcontentLinks,
+  filterSubcontentLinks,
   addEnglishNames,
   sortLanguageByNameOrEnglishName,
   sortContents,
@@ -50,6 +52,8 @@ function massage(data) {
   result = filterSubcontents(result);
   result = mapSubcontentLinks(result);
   result = addAdditionalData(result);
+  result = filterContentLinks(result);
+  result = filterSubcontentLinks(result);
   result = addEnglishNames(langData, result);
   result = sortLanguageByNameOrEnglishName(result);
   result = sortContents(contentOrderData, result);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon index.js",
+    "start": "node index.js",
     "test": "jest --watch"
   },
   "author": "",


### PR DESCRIPTION
This PR includes the following changes:

- Only show Download links for resources of type ulb, udb, reg
- Fix race condition that could cause the internal http server to restart in the middle of serving the page
