### PR TITLE
Remove empty sections

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -74,6 +74,17 @@ function filterContents(languages) {
     }));
 }
 
+function filterEmptyContents(languages) {
+    return languages.map(l => ({
+        ...l,
+        contents: l.contents.filter((c) => {
+            linksExist = c.links && c.links.length > 0;
+            subcontentsExist = c.subcontents && c.subcontents.length > 0;
+            return linksExist || subcontentsExist;
+        })
+    }));
+}
+
 function filterContentLinks(languages) {
   return languages.map(l => ({
     ...l,
@@ -342,6 +353,7 @@ module.exports = {
   mapContentLinks,
   filterContentLinks,
   filterContents,
+  filterEmptyContents,
   mapSubcontents,
   filterSubcontents,
   mapSubcontentLinks,

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const {
   mapContentLinks,
   filterContentLinks,
   filterContents,
+  filterEmptyContents,
   mapSubcontents,
   filterSubcontents,
   mapSubcontentLinks,
@@ -60,6 +61,7 @@ function massage(data) {
   result = sortSubContents(result);
   result = unnestSubcontents(result);
   result = filterContents(result);
+  result = filterEmptyContents(result);
 
   return result;
 }


### PR DESCRIPTION
This change removes empty sections from the list of translations used by BIEL.  This prevents e.g. an empty "Unknown" section from appearing on the language translation pages.