### PR TITLE
Get language name and direction from langnames.json

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -208,12 +208,14 @@ function filterSubcontentLinks(languages) {
   }));
 }
 
-function addEnglishNames(langNameData, languages) {
+function updateFromLangNames(langNameData, languages) {
   return languages.map((l) => {
     const data = langNameData.find(lang => lang.lc === l.code);
     return {
       ...l,
+      name: (data && data.ln) || '',
       englishName: (data && data.ang) || '',
+      direction: (data && data.ld) || ''
     };
   });
 }
@@ -379,7 +381,7 @@ module.exports = {
   filterSubcontents,
   mapSubcontentLinks,
   filterSubcontentLinks,
-  addEnglishNames,
+  updateFromLangNames: updateFromLangNames,
   sortLanguageByNameOrEnglishName,
   sortContents,
   sortSubContents,

--- a/functions.js
+++ b/functions.js
@@ -381,7 +381,7 @@ module.exports = {
   filterSubcontents,
   mapSubcontentLinks,
   filterSubcontentLinks,
-  updateFromLangNames: updateFromLangNames,
+  updateFromLangNames,
   sortLanguageByNameOrEnglishName,
   sortContents,
   sortSubContents,

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const {
   filterSubcontents,
   mapSubcontentLinks,
   filterSubcontentLinks,
-  addEnglishNames,
+  updateFromLangNames,
   sortLanguageByNameOrEnglishName,
   sortContents,
   sortSubContents,
@@ -56,7 +56,7 @@ function massage(data) {
   result = addAdditionalData(result);
   result = filterContentLinks(result);
   result = filterSubcontentLinks(result);
-  result = addEnglishNames(langData, result);
+  result = updateFromLangNames(langData, result);
   result = sortLanguageByNameOrEnglishName(result);
   result = sortContents(contentOrderData, result);
   result = sortSubContents(result);


### PR DESCRIPTION
This change pulls the language name and direction from langnames.json rather than the catalog.